### PR TITLE
Fix broken "some examples" readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Javascript / Typescript Seam API Library & CLI
 
 Control locks, lights and other internet of things devices with Seam's simple
-API. Check out [the documentation](./docs/modules.md) or [some examples](./examples).
+API.
+
+Check out [the documentation](./docs/modules.md) or some examples:
+- [CLI Usage](#cli-usage)
+- [Library Usage](#library-usage)
+- [Receiving Webhooks](#receiving-webhooks)
 
 ## Usage
 


### PR DESCRIPTION
This proposes a possible fix for the broken "some examples" link at the top of https://github.com/seamapi/javascript/blob/main/README.md.

The paragraph with the examples link appears to have been copied, in commit adbaadba72d8129cb83ace689fecf8b1d2f3f706, from the python repo's readme. The python repo has an [examples directory](https://github.com/seamapi/python/tree/main/examples), so the link there works. But, the examples for the javascript repo are in the readme under the Usage heading (added by PR https://github.com/seamapi/javascript/pull/4).

My proposed fix is to swap the link to the non-existent examples directory for a list of links to Usage subheading anchors in the readme.
