### PR TITLE
fix #66: Adjust Docker container reference

### DIFF
--- a/tests/fixtures/workers/helpers/start-and-seed-server.ts
+++ b/tests/fixtures/workers/helpers/start-and-seed-server.ts
@@ -34,8 +34,7 @@ const startAndSeedServer = async () => {
   const serverUrl = `http://localhost:${hostPort}`
 
   const server = await new GenericContainer(
-    process.env.SEAM_CONNECT_IMAGE ??
-      "registry.digitalocean.com/seam/seam-connect"
+    process.env.SEAM_CONNECT_IMAGE ?? "ghcr.io/seamapi/seam-connect:latest"
   )
     .withExposedPorts({
       container: hostPort,


### PR DESCRIPTION
The same thing had to be done with the Python SDK. Chances are, these GH tests will fail, too.