### PR TITLE
Skiptest until seam connect issue resolved

### DIFF
--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -4,13 +4,14 @@ import { SeamWebhook } from "../src"
 import mockWebhook from "./fixtures/mock-webhook"
 import { getServer } from "./fixtures/plugins/get-server-plugin"
 
-test("webhook payload is correctly verified", async (t) => {
+test.skip("webhook payload is correctly verified", async (t) => {
   const { axios, client, seed } = await getServer(true)
 
   const { endpoint, waitForCallback } = await mockWebhook()
 
   const webhookCreationResponse = await axios.post("/webhooks/create", {
     url: endpoint,
+    event_types: ["access_code.created"],
   })
   const { secret } = webhookCreationResponse.data.webhook
 


### PR DESCRIPTION
`event_types` aren't working on seam connect at the moment, so this test can't subscribe properly to `access_code.created` w/o subscribing to `access_code.changed`