### PR TITLE
feat: Add event_id to event response, move seamapi-types to prod dependencies

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -332,7 +332,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:189](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L189)
+[src/types/models.ts:190](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L190)
 
 ___
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ora": "5.4.1",
     "p-retry": "4.6.1",
     "prompts": "2.4.2",
+    "seamapi-types": "1.11.0",
     "svix": "0.54.2",
     "typed-emitter": "2.1.0",
     "yargs": "17.3.1"
@@ -83,7 +84,6 @@
     "pkg": "5.5.2",
     "playwright": "1.19.2",
     "prettier": "2.5.1",
-    "seamapi-types": "1.3.10",
     "semantic-release": "19.0.2",
     "testcontainers": "8.4.0",
     "ts-json-schema-generator": "0.98.0",

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -182,6 +182,7 @@ export interface Webhook {
 type Flatten<EventType extends SeamEvent["event_type"]> =
   EventType extends SeamEvent["event_type"]
     ? {
+        event_id: string
         event_type: EventType
       } & Extract<SeamEvent, { event_type: EventType }>["payload"]
     : never

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -39,7 +39,7 @@ test.skip("webhook payload is correctly verified", async (t) => {
   )
 
   t.is(callback.event_type, "access_code.created")
-  t.is(callback.data.device_id, seed.devices.augustLock.id1)
+  t.is((callback.data as any).device_id, seed.devices.augustLock.id1)
   // Check types
   t.true(
     callback.event_type === "access_code.created" &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -5094,10 +5094,10 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-seamapi-types@1.3.10:
-  version "1.3.10"
-  resolved "https://registry.yarnpkg.com/seamapi-types/-/seamapi-types-1.3.10.tgz#d90dcb140872226301bbff428e2d34b31ca174ec"
-  integrity sha512-OEZGrwp1A3oz60AbDrfvRIlz3SrURJZeY5jH4SiYG5mjKnoRdchkAjo7uCZOPrldadch2wiAojWD+qp2UOGdnA==
+seamapi-types@1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/seamapi-types/-/seamapi-types-1.11.0.tgz#ed62fcf9173bb8f540036b999b3ce7e0275affac"
+  integrity sha512-bo4bVjc3tbnS1jl8S/KGbfgS4bbrOhDTaORW0Cg6eLcd+3iDmwvatAPYFBmNNekj2IOcMKhMMrqbpldC4d8jGA==
 
 semantic-release@19.0.2:
   version "19.0.2"


### PR DESCRIPTION
Typescript doesn't bundle types from seamapi-types, meaning that unless a consumer also installs seamapi-types `events.list(...)` will return `Promise<any[]>`.
