### PR TITLE
Return Access Codes Immediately Instead of Waiting for Action Attempt

### DIFF
--- a/docs/classes/Seam.md
+++ b/docs/classes/Seam.md
@@ -49,7 +49,7 @@ Routes.constructor
 
 #### Defined in
 
-[src/client.ts:44](https://github.com/seamapi/javascript/blob/main/src/client.ts#L44)
+[src/client.ts:44](https://github.com/seamapi/seamapi-javascript/blob/main/src/client.ts#L44)
 
 ## Properties
 
@@ -61,7 +61,7 @@ Routes.constructor
 
 | Name | Type |
 | :------ | :------ |
-| `create` | (`params`: [`AccessCodeCreateOngoingRequest`](../interfaces/AccessCodeCreateOngoingRequest.md)) => `Promise`<[`OngoingAccessCode`](../interfaces/OngoingAccessCode.md)\>(`params`: [`AccessCodeCreateScheduledRequest`](../interfaces/AccessCodeCreateScheduledRequest.md)) => `Promise`<[`TimeBoundAccessCode`](../interfaces/TimeBoundAccessCode.md)\> |
+| `create` | (`params`: [`AccessCodeCreateRequest`](../modules.md#accesscodecreaterequest)) => `Promise`<(`params`: [`AccessCodeCreateOngoingRequest`](../interfaces/AccessCodeCreateOngoingRequest.md)) => `Promise`<[`OngoingAccessCode`](../interfaces/OngoingAccessCode.md)\>(`params`: [`AccessCodeCreateScheduledRequest`](../interfaces/AccessCodeCreateScheduledRequest.md)) => `Promise`<[`TimeBoundAccessCode`](../interfaces/TimeBoundAccessCode.md)\>\> |
 | `delete` | (`params`: [`AccessCodeDeleteRequest`](../modules.md#accesscodedeleterequest)) => `Promise`<`unknown`\> |
 | `get` | (`params`: [`AccessCodeGetRequest`](../modules.md#accesscodegetrequest)) => `Promise`<[`AccessCode`](../modules.md#accesscode)\> |
 | `list` | (`params`: { `device_id`: `string`  }) => `Promise`<[`AccessCode`](../modules.md#accesscode)[]\> |
@@ -73,7 +73,7 @@ Routes.accessCodes
 
 #### Defined in
 
-[src/routes.ts:230](https://github.com/seamapi/javascript/blob/main/src/routes.ts#L230)
+[src/routes.ts:230](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L230)
 
 ___
 
@@ -93,7 +93,7 @@ Routes.actionAttempts
 
 #### Defined in
 
-[src/routes.ts:302](https://github.com/seamapi/javascript/blob/main/src/routes.ts#L302)
+[src/routes.ts:298](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L298)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[src/client.ts:42](https://github.com/seamapi/javascript/blob/main/src/client.ts#L42)
+[src/client.ts:42](https://github.com/seamapi/seamapi-javascript/blob/main/src/client.ts#L42)
 
 ___
 
@@ -126,7 +126,7 @@ Routes.connectWebviews
 
 #### Defined in
 
-[src/routes.ts:198](https://github.com/seamapi/javascript/blob/main/src/routes.ts#L198)
+[src/routes.ts:198](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L198)
 
 ___
 
@@ -148,7 +148,7 @@ Routes.connectedAccounts
 
 #### Defined in
 
-[src/routes.ts:277](https://github.com/seamapi/javascript/blob/main/src/routes.ts#L277)
+[src/routes.ts:273](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L273)
 
 ___
 
@@ -171,7 +171,7 @@ Routes.devices
 
 #### Defined in
 
-[src/routes.ts:161](https://github.com/seamapi/javascript/blob/main/src/routes.ts#L161)
+[src/routes.ts:161](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L161)
 
 ___
 
@@ -191,7 +191,7 @@ Routes.events
 
 #### Defined in
 
-[src/routes.ts:186](https://github.com/seamapi/javascript/blob/main/src/routes.ts#L186)
+[src/routes.ts:186](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L186)
 
 ___
 
@@ -214,7 +214,7 @@ Routes.locks
 
 #### Defined in
 
-[src/routes.ts:126](https://github.com/seamapi/javascript/blob/main/src/routes.ts#L126)
+[src/routes.ts:126](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L126)
 
 ___
 
@@ -237,7 +237,7 @@ Routes.webhooks
 
 #### Defined in
 
-[src/routes.ts:312](https://github.com/seamapi/javascript/blob/main/src/routes.ts#L312)
+[src/routes.ts:308](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L308)
 
 ___
 
@@ -259,7 +259,7 @@ Routes.workspaces
 
 #### Defined in
 
-[src/routes.ts:110](https://github.com/seamapi/javascript/blob/main/src/routes.ts#L110)
+[src/routes.ts:110](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L110)
 
 ## Methods
 
@@ -289,4 +289,4 @@ Routes.makeRequest
 
 #### Defined in
 
-[src/client.ts:82](https://github.com/seamapi/javascript/blob/main/src/client.ts#L82)
+[src/client.ts:82](https://github.com/seamapi/seamapi-javascript/blob/main/src/client.ts#L82)

--- a/docs/classes/SeamAPIError.md
+++ b/docs/classes/SeamAPIError.md
@@ -50,7 +50,7 @@ Error.constructor
 
 #### Defined in
 
-[src/lib/api-error.ts:8](https://github.com/seamapi/javascript/blob/main/src/lib/api-error.ts#L8)
+[src/lib/api-error.ts:8](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L8)
 
 ## Properties
 
@@ -171,7 +171,7 @@ node_modules/@types/node/globals.d.ts:13
 
 #### Defined in
 
-[src/lib/api-error.ts:20](https://github.com/seamapi/javascript/blob/main/src/lib/api-error.ts#L20)
+[src/lib/api-error.ts:20](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L20)
 
 ___
 

--- a/docs/classes/SeamActionAttemptError.md
+++ b/docs/classes/SeamActionAttemptError.md
@@ -49,7 +49,7 @@ Error.constructor
 
 #### Defined in
 
-[src/lib/api-error.ts:26](https://github.com/seamapi/javascript/blob/main/src/lib/api-error.ts#L26)
+[src/lib/api-error.ts:26](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L26)
 
 ## Properties
 
@@ -160,7 +160,7 @@ node_modules/@types/node/globals.d.ts:13
 
 #### Defined in
 
-[src/lib/api-error.ts:38](https://github.com/seamapi/javascript/blob/main/src/lib/api-error.ts#L38)
+[src/lib/api-error.ts:38](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L38)
 
 ___
 

--- a/docs/classes/SeamMalformedInputError.md
+++ b/docs/classes/SeamMalformedInputError.md
@@ -46,7 +46,7 @@ Error.constructor
 
 #### Defined in
 
-[src/lib/api-error.ts:44](https://github.com/seamapi/javascript/blob/main/src/lib/api-error.ts#L44)
+[src/lib/api-error.ts:44](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L44)
 
 ## Properties
 
@@ -155,7 +155,7 @@ node_modules/@types/node/globals.d.ts:13
 
 #### Defined in
 
-[src/lib/api-error.ts:52](https://github.com/seamapi/javascript/blob/main/src/lib/api-error.ts#L52)
+[src/lib/api-error.ts:52](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L52)
 
 ___
 

--- a/docs/classes/SeamWebhook.md
+++ b/docs/classes/SeamWebhook.md
@@ -34,7 +34,7 @@ Create a new instance of SeamWebhook.
 
 #### Defined in
 
-[src/webhooks.ts:14](https://github.com/seamapi/javascript/blob/main/src/webhooks.ts#L14)
+[src/webhooks.ts:14](https://github.com/seamapi/seamapi-javascript/blob/main/src/webhooks.ts#L14)
 
 ## Properties
 
@@ -44,7 +44,7 @@ Create a new instance of SeamWebhook.
 
 #### Defined in
 
-[src/webhooks.ts:8](https://github.com/seamapi/javascript/blob/main/src/webhooks.ts#L8)
+[src/webhooks.ts:8](https://github.com/seamapi/seamapi-javascript/blob/main/src/webhooks.ts#L8)
 
 ## Methods
 
@@ -69,4 +69,4 @@ event
 
 #### Defined in
 
-[src/webhooks.ts:24](https://github.com/seamapi/javascript/blob/main/src/webhooks.ts#L24)
+[src/webhooks.ts:24](https://github.com/seamapi/seamapi-javascript/blob/main/src/webhooks.ts#L24)

--- a/docs/enums/Provider.md
+++ b/docs/enums/Provider.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[src/types/models.ts:18](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L18)
+[src/types/models.ts:18](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L18)
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:19](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L19)
+[src/types/models.ts:19](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L19)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:20](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L20)
+[src/types/models.ts:20](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L20)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:24](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L24)
+[src/types/models.ts:24](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L24)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:21](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L21)
+[src/types/models.ts:21](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L21)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:22](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L22)
+[src/types/models.ts:22](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L22)
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:25](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L25)
+[src/types/models.ts:25](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L25)
 
 ___
 
@@ -93,4 +93,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:23](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L23)
+[src/types/models.ts:23](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L23)

--- a/docs/interfaces/APIErrorResponse.md
+++ b/docs/interfaces/APIErrorResponse.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[src/types/globals.ts:4](https://github.com/seamapi/javascript/blob/main/src/types/globals.ts#L4)
+[src/types/globals.ts:4](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L4)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[src/types/globals.ts:3](https://github.com/seamapi/javascript/blob/main/src/types/globals.ts#L3)
+[src/types/globals.ts:3](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L3)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[src/types/globals.ts:2](https://github.com/seamapi/javascript/blob/main/src/types/globals.ts#L2)
+[src/types/globals.ts:2](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L2)

--- a/docs/interfaces/AccessCodeBase.md
+++ b/docs/interfaces/AccessCodeBase.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[src/types/models.ts:139](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L139)
+[src/types/models.ts:139](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L139)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:142](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L142)
+[src/types/models.ts:142](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L142)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:140](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L140)
+[src/types/models.ts:140](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L140)
 
 ___
 
@@ -57,4 +57,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:141](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L141)
+[src/types/models.ts:141](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L141)

--- a/docs/interfaces/AccessCodeCreateBaseRequest.md
+++ b/docs/interfaces/AccessCodeCreateBaseRequest.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:32](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L32)
+[src/types/route-requests.ts:32](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L32)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:30](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L30)
+[src/types/route-requests.ts:30](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L30)
 
 ___
 
@@ -46,4 +46,4 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:31](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L31)
+[src/types/route-requests.ts:31](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L31)

--- a/docs/interfaces/AccessCodeCreateOngoingRequest.md
+++ b/docs/interfaces/AccessCodeCreateOngoingRequest.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:32](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L32)
+[src/types/route-requests.ts:32](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L32)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:30](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L30)
+[src/types/route-requests.ts:30](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L30)
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:31](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L31)
+[src/types/route-requests.ts:31](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L31)

--- a/docs/interfaces/AccessCodeCreateScheduledRequest.md
+++ b/docs/interfaces/AccessCodeCreateScheduledRequest.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:32](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L32)
+[src/types/route-requests.ts:32](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L32)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:30](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L30)
+[src/types/route-requests.ts:30](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L30)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:41](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L41)
+[src/types/route-requests.ts:41](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L41)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:31](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L31)
+[src/types/route-requests.ts:31](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L31)
 
 ___
 
@@ -78,4 +78,4 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:40](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L40)
+[src/types/route-requests.ts:40](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L40)

--- a/docs/interfaces/AccessCodeGetResponse.md
+++ b/docs/interfaces/AccessCodeGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:63](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L63)
+[src/types/route-responses.ts:63](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L63)

--- a/docs/interfaces/AccessCodeUpdateBaseRequest.md
+++ b/docs/interfaces/AccessCodeUpdateBaseRequest.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:50](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L50)
+[src/types/route-requests.ts:50](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L50)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:49](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L49)
+[src/types/route-requests.ts:49](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L49)

--- a/docs/interfaces/AccessCodesListResponse.md
+++ b/docs/interfaces/AccessCodesListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:60](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L60)
+[src/types/route-responses.ts:60](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L60)

--- a/docs/interfaces/ActionAttemptCreateResponse.md
+++ b/docs/interfaces/ActionAttemptCreateResponse.md
@@ -22,4 +22,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:88](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L88)
+[src/types/route-responses.ts:88](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L88)

--- a/docs/interfaces/ActionAttemptGetResponse.md
+++ b/docs/interfaces/ActionAttemptGetResponse.md
@@ -22,4 +22,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:92](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L92)
+[src/types/route-responses.ts:92](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L92)

--- a/docs/interfaces/ActionAttemptResultTypeMap.md
+++ b/docs/interfaces/ActionAttemptResultTypeMap.md
@@ -36,7 +36,7 @@ Record.CREATE\_ACCESS\_CODE
 
 #### Defined in
 
-[src/types/models.ts:105](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L105)
+[src/types/models.ts:105](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L105)
 
 ___
 
@@ -86,4 +86,4 @@ Record.UPDATE\_ACCESS\_CODE
 
 #### Defined in
 
-[src/types/models.ts:106](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L106)
+[src/types/models.ts:106](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L106)

--- a/docs/interfaces/ActionAttemptWithError.md
+++ b/docs/interfaces/ActionAttemptWithError.md
@@ -36,7 +36,7 @@ ActionAttemptBase.action\_attempt\_id
 
 #### Defined in
 
-[src/types/models.ts:79](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L79)
+[src/types/models.ts:79](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L79)
 
 ___
 
@@ -50,7 +50,7 @@ ActionAttemptBase.action\_type
 
 #### Defined in
 
-[src/types/models.ts:80](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L80)
+[src/types/models.ts:80](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L80)
 
 ___
 
@@ -71,7 +71,7 @@ ActionAttemptBase.error
 
 #### Defined in
 
-[src/types/models.ts:97](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L97)
+[src/types/models.ts:97](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L97)
 
 ___
 
@@ -85,7 +85,7 @@ ActionAttemptBase.result
 
 #### Defined in
 
-[src/types/models.ts:96](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L96)
+[src/types/models.ts:96](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L96)
 
 ___
 
@@ -99,4 +99,4 @@ ActionAttemptBase.status
 
 #### Defined in
 
-[src/types/models.ts:95](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L95)
+[src/types/models.ts:95](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L95)

--- a/docs/interfaces/ConnectWebview.md
+++ b/docs/interfaces/ConnectWebview.md
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[src/types/models.ts:126](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L126)
+[src/types/models.ts:126](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L126)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:125](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L125)
+[src/types/models.ts:125](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L125)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:128](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L128)
+[src/types/models.ts:128](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L128)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:127](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L127)
+[src/types/models.ts:127](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L127)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:135](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L135)
+[src/types/models.ts:135](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L135)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:122](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L122)
+[src/types/models.ts:122](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L122)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:132](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L132)
+[src/types/models.ts:132](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L132)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:129](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L129)
+[src/types/models.ts:129](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L129)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:133](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L133)
+[src/types/models.ts:133](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L133)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:124](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L124)
+[src/types/models.ts:124](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L124)
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:130](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L130)
+[src/types/models.ts:130](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L130)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:131](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L131)
+[src/types/models.ts:131](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L131)
 
 ___
 
@@ -149,7 +149,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:134](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L134)
+[src/types/models.ts:134](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L134)
 
 ___
 
@@ -159,4 +159,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:123](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L123)
+[src/types/models.ts:123](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L123)

--- a/docs/interfaces/ConnectWebviewCreateRequest.md
+++ b/docs/interfaces/ConnectWebviewCreateRequest.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:5](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L5)
+[src/types/route-requests.ts:5](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L5)

--- a/docs/interfaces/ConnectWebviewCreateResponse.md
+++ b/docs/interfaces/ConnectWebviewCreateResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:53](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L53)
+[src/types/route-responses.ts:53](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L53)

--- a/docs/interfaces/ConnectWebviewDeleteRequest.md
+++ b/docs/interfaces/ConnectWebviewDeleteRequest.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:9](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L9)
+[src/types/route-requests.ts:9](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L9)

--- a/docs/interfaces/ConnectWebviewGetResponse.md
+++ b/docs/interfaces/ConnectWebviewGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:50](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L50)
+[src/types/route-responses.ts:50](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L50)

--- a/docs/interfaces/ConnectWebviewsListResponse.md
+++ b/docs/interfaces/ConnectWebviewsListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:47](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L47)
+[src/types/route-responses.ts:47](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L47)

--- a/docs/interfaces/ConnectedAccount.md
+++ b/docs/interfaces/ConnectedAccount.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[src/types/models.ts:169](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L169)
+[src/types/models.ts:169](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L169)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:166](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L166)
+[src/types/models.ts:166](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L166)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:167](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L167)
+[src/types/models.ts:167](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L167)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:170](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L170)
+[src/types/models.ts:170](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L170)
 
 ___
 
@@ -60,4 +60,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:168](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L168)
+[src/types/models.ts:168](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L168)

--- a/docs/interfaces/ConnectedAccountsDeleteRequest.md
+++ b/docs/interfaces/ConnectedAccountsDeleteRequest.md
@@ -27,7 +27,7 @@ ConnectedAccountBaseRequest.connected\_account\_id
 
 #### Defined in
 
-[src/types/route-requests.ts:13](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L13)
+[src/types/route-requests.ts:13](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L13)
 
 ___
 
@@ -41,4 +41,4 @@ ConnectedAccountBaseRequest.email
 
 #### Defined in
 
-[src/types/route-requests.ts:14](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L14)
+[src/types/route-requests.ts:14](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L14)

--- a/docs/interfaces/ConnectedAccountsGetRequest.md
+++ b/docs/interfaces/ConnectedAccountsGetRequest.md
@@ -27,7 +27,7 @@ ConnectedAccountBaseRequest.connected\_account\_id
 
 #### Defined in
 
-[src/types/route-requests.ts:13](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L13)
+[src/types/route-requests.ts:13](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L13)
 
 ___
 
@@ -41,4 +41,4 @@ ConnectedAccountBaseRequest.email
 
 #### Defined in
 
-[src/types/route-requests.ts:14](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L14)
+[src/types/route-requests.ts:14](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L14)

--- a/docs/interfaces/ConnectedAccountsGetResponse.md
+++ b/docs/interfaces/ConnectedAccountsGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:71](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L71)
+[src/types/route-responses.ts:71](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L71)

--- a/docs/interfaces/ConnectedAccountsListResponse.md
+++ b/docs/interfaces/ConnectedAccountsListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:68](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L68)
+[src/types/route-responses.ts:68](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L68)

--- a/docs/interfaces/Device.md
+++ b/docs/interfaces/Device.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/types/models.ts:42](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L42)
+[src/types/models.ts:42](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L42)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:41](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L41)
+[src/types/models.ts:41](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L41)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:44](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L44)
+[src/types/models.ts:44](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L44)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:36](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L36)
+[src/types/models.ts:36](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L36)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:40](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L40)
+[src/types/models.ts:40](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L40)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:43](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L43)
+[src/types/models.ts:43](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L43)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:39](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L39)
+[src/types/models.ts:39](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L39)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:38](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L38)
+[src/types/models.ts:38](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L38)
 
 ___
 
@@ -111,4 +111,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:37](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L37)
+[src/types/models.ts:37](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L37)

--- a/docs/interfaces/DeviceGetResponse.md
+++ b/docs/interfaces/DeviceGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:42](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L42)
+[src/types/route-responses.ts:42](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L42)

--- a/docs/interfaces/DevicesListRequest.md
+++ b/docs/interfaces/DevicesListRequest.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:25](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L25)
+[src/types/route-requests.ts:25](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L25)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:24](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L24)
+[src/types/route-requests.ts:24](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L24)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:26](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L26)
+[src/types/route-requests.ts:26](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L26)

--- a/docs/interfaces/DevicesListResponse.md
+++ b/docs/interfaces/DevicesListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:39](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L39)
+[src/types/route-responses.ts:39](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L39)

--- a/docs/interfaces/ErroredAPIResponse.md
+++ b/docs/interfaces/ErroredAPIResponse.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[src/types/globals.ts:13](https://github.com/seamapi/javascript/blob/main/src/types/globals.ts#L13)
+[src/types/globals.ts:13](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L13)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[src/types/globals.ts:12](https://github.com/seamapi/javascript/blob/main/src/types/globals.ts#L12)
+[src/types/globals.ts:12](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L12)

--- a/docs/interfaces/EventsListRequest.md
+++ b/docs/interfaces/EventsListRequest.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:108](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L108)
+[src/types/route-requests.ts:108](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L108)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:107](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L107)
+[src/types/route-requests.ts:107](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L107)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:110](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L110)
+[src/types/route-requests.ts:110](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L110)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:109](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L109)
+[src/types/route-requests.ts:109](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L109)
 
 ___
 
@@ -60,4 +60,4 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:106](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L106)
+[src/types/route-requests.ts:106](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L106)

--- a/docs/interfaces/EventsListResponse.md
+++ b/docs/interfaces/EventsListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:97](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L97)
+[src/types/route-responses.ts:97](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L97)

--- a/docs/interfaces/LockGetResponse.md
+++ b/docs/interfaces/LockGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:34](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L34)
+[src/types/route-responses.ts:34](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L34)

--- a/docs/interfaces/LockProperties.md
+++ b/docs/interfaces/LockProperties.md
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[src/types/models.ts:58](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L58)
+[src/types/models.ts:58](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L58)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:50](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L50)
+[src/types/models.ts:50](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L50)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:49](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L49)
+[src/types/models.ts:49](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L49)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:48](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L48)
+[src/types/models.ts:48](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L48)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:51](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L51)
+[src/types/models.ts:51](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L51)
 
 ___
 
@@ -93,7 +93,7 @@ CommonDeviceProperties.name
 
 #### Defined in
 
-[src/types/models.ts:29](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L29)
+[src/types/models.ts:29](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L29)
 
 ___
 
@@ -107,7 +107,7 @@ CommonDeviceProperties.online
 
 #### Defined in
 
-[src/types/models.ts:30](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L30)
+[src/types/models.ts:30](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L30)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:53](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L53)
+[src/types/models.ts:53](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L53)
 
 ___
 
@@ -134,4 +134,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:65](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L65)
+[src/types/models.ts:65](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L65)

--- a/docs/interfaces/LocksListResponse.md
+++ b/docs/interfaces/LocksListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:30](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L30)
+[src/types/route-responses.ts:30](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L30)

--- a/docs/interfaces/OngoingAccessCode.md
+++ b/docs/interfaces/OngoingAccessCode.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[src/types/models.ts:139](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L139)
+[src/types/models.ts:139](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L139)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:142](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L142)
+[src/types/models.ts:142](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L142)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:147](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L147)
+[src/types/models.ts:147](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L147)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:140](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L140)
+[src/types/models.ts:140](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L140)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:141](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L141)
+[src/types/models.ts:141](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L141)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:148](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L148)
+[src/types/models.ts:148](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L148)
 
 ___
 
@@ -104,4 +104,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:146](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L146)
+[src/types/models.ts:146](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L146)

--- a/docs/interfaces/PendingActionAttempt.md
+++ b/docs/interfaces/PendingActionAttempt.md
@@ -36,7 +36,7 @@ ActionAttemptBase.action\_attempt\_id
 
 #### Defined in
 
-[src/types/models.ts:79](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L79)
+[src/types/models.ts:79](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L79)
 
 ___
 
@@ -50,7 +50,7 @@ ActionAttemptBase.action\_type
 
 #### Defined in
 
-[src/types/models.ts:80](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L80)
+[src/types/models.ts:80](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L80)
 
 ___
 
@@ -64,7 +64,7 @@ ActionAttemptBase.error
 
 #### Defined in
 
-[src/types/models.ts:90](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L90)
+[src/types/models.ts:90](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L90)
 
 ___
 
@@ -78,7 +78,7 @@ ActionAttemptBase.result
 
 #### Defined in
 
-[src/types/models.ts:89](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L89)
+[src/types/models.ts:89](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L89)
 
 ___
 
@@ -92,4 +92,4 @@ ActionAttemptBase.status
 
 #### Defined in
 
-[src/types/models.ts:88](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L88)
+[src/types/models.ts:88](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L88)

--- a/docs/interfaces/SeamAPIErrorMetadata.md
+++ b/docs/interfaces/SeamAPIErrorMetadata.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[src/lib/api-error.ts:4](https://github.com/seamapi/javascript/blob/main/src/lib/api-error.ts#L4)
+[src/lib/api-error.ts:4](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L4)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[src/lib/api-error.ts:3](https://github.com/seamapi/javascript/blob/main/src/lib/api-error.ts#L3)
+[src/lib/api-error.ts:3](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L3)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[src/lib/api-error.ts:2](https://github.com/seamapi/javascript/blob/main/src/lib/api-error.ts#L2)
+[src/lib/api-error.ts:2](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L2)

--- a/docs/interfaces/SeamClientOptions.md
+++ b/docs/interfaces/SeamClientOptions.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/client.ts:10](https://github.com/seamapi/javascript/blob/main/src/client.ts#L10)
+[src/client.ts:10](https://github.com/seamapi/seamapi-javascript/blob/main/src/client.ts#L10)
 
 ___
 
@@ -31,7 +31,7 @@ Extended options to pass to Axios
 
 #### Defined in
 
-[src/client.ts:23](https://github.com/seamapi/javascript/blob/main/src/client.ts#L23)
+[src/client.ts:23](https://github.com/seamapi/seamapi-javascript/blob/main/src/client.ts#L23)
 
 ___
 
@@ -43,7 +43,7 @@ Seam Endpoint to use, defaults to https://connect.getseam.com
 
 #### Defined in
 
-[src/client.ts:14](https://github.com/seamapi/javascript/blob/main/src/client.ts#L14)
+[src/client.ts:14](https://github.com/seamapi/seamapi-javascript/blob/main/src/client.ts#L14)
 
 ___
 
@@ -56,4 +56,4 @@ or undefined
 
 #### Defined in
 
-[src/client.ts:19](https://github.com/seamapi/javascript/blob/main/src/client.ts#L19)
+[src/client.ts:19](https://github.com/seamapi/seamapi-javascript/blob/main/src/client.ts#L19)

--- a/docs/interfaces/SuccessfulActionAttempt.md
+++ b/docs/interfaces/SuccessfulActionAttempt.md
@@ -36,7 +36,7 @@ ActionAttemptBase.action\_attempt\_id
 
 #### Defined in
 
-[src/types/models.ts:79](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L79)
+[src/types/models.ts:79](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L79)
 
 ___
 
@@ -50,7 +50,7 @@ ActionAttemptBase.action\_type
 
 #### Defined in
 
-[src/types/models.ts:80](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L80)
+[src/types/models.ts:80](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L80)
 
 ___
 
@@ -64,7 +64,7 @@ ActionAttemptBase.error
 
 #### Defined in
 
-[src/types/models.ts:112](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L112)
+[src/types/models.ts:112](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L112)
 
 ___
 
@@ -78,7 +78,7 @@ ActionAttemptBase.result
 
 #### Defined in
 
-[src/types/models.ts:113](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L113)
+[src/types/models.ts:113](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L113)
 
 ___
 
@@ -92,4 +92,4 @@ ActionAttemptBase.status
 
 #### Defined in
 
-[src/types/models.ts:111](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L111)
+[src/types/models.ts:111](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L111)

--- a/docs/interfaces/TimeBoundAccessCode.md
+++ b/docs/interfaces/TimeBoundAccessCode.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[src/types/models.ts:139](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L139)
+[src/types/models.ts:139](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L139)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:142](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L142)
+[src/types/models.ts:142](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L142)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:153](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L153)
+[src/types/models.ts:153](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L153)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:140](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L140)
+[src/types/models.ts:140](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L140)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:156](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L156)
+[src/types/models.ts:156](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L156)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:141](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L141)
+[src/types/models.ts:141](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L141)
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:155](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L155)
+[src/types/models.ts:155](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L155)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:154](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L154)
+[src/types/models.ts:154](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L154)
 
 ___
 
@@ -126,4 +126,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:152](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L152)
+[src/types/models.ts:152](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L152)

--- a/docs/interfaces/UserIdentifier.md
+++ b/docs/interfaces/UserIdentifier.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/models.ts:162](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L162)
+[src/types/models.ts:162](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L162)

--- a/docs/interfaces/Webhook.md
+++ b/docs/interfaces/Webhook.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/types/models.ts:176](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L176)
+[src/types/models.ts:176](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L176)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:177](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L177)
+[src/types/models.ts:177](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L177)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:175](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L175)
+[src/types/models.ts:175](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L175)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:174](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L174)
+[src/types/models.ts:174](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L174)

--- a/docs/interfaces/WebhookGetResponse.md
+++ b/docs/interfaces/WebhookGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:80](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L80)
+[src/types/route-responses.ts:80](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L80)

--- a/docs/interfaces/WebhookListResponse.md
+++ b/docs/interfaces/WebhookListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:76](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L76)
+[src/types/route-responses.ts:76](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L76)

--- a/docs/interfaces/Workspace.md
+++ b/docs/interfaces/Workspace.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/types/models.ts:4](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L4)
+[src/types/models.ts:4](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L4)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:6](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L6)
+[src/types/models.ts:6](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L6)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:5](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L5)
+[src/types/models.ts:5](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L5)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:3](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L3)
+[src/types/models.ts:3](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L3)

--- a/docs/interfaces/WorkspaceGetResponse.md
+++ b/docs/interfaces/WorkspaceGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:20](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L20)
+[src/types/route-responses.ts:20](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L20)

--- a/docs/interfaces/WorkspaceResetSandboxResponse.md
+++ b/docs/interfaces/WorkspaceResetSandboxResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:25](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L25)
+[src/types/route-responses.ts:25](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L25)

--- a/docs/interfaces/WorkspacesListResponse.md
+++ b/docs/interfaces/WorkspacesListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:17](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L17)
+[src/types/route-responses.ts:17](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L17)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -121,7 +121,7 @@ Renames and re-exports [Seam](classes/Seam.md)
 
 #### Defined in
 
-[src/types/globals.ts:16](https://github.com/seamapi/javascript/blob/main/src/types/globals.ts#L16)
+[src/types/globals.ts:16](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L16)
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:159](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L159)
+[src/types/models.ts:159](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L159)
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:44](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L44)
+[src/types/route-requests.ts:44](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L44)
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:67](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L67)
+[src/types/route-requests.ts:67](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L67)
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:72](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L72)
+[src/types/route-requests.ts:72](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L72)
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:53](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L53)
+[src/types/route-requests.ts:53](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L53)
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:63](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L63)
+[src/types/route-requests.ts:63](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L63)
 
 ___
 
@@ -206,7 +206,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:58](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L58)
+[src/types/route-requests.ts:58](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L58)
 
 ___
 
@@ -222,7 +222,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:116](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L116)
+[src/types/models.ts:116](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L116)
 
 ___
 
@@ -232,7 +232,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:71](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L71)
+[src/types/models.ts:71](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L71)
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:68](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L68)
+[src/types/models.ts:68](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L68)
 
 ___
 
@@ -259,7 +259,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:28](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L28)
+[src/types/models.ts:28](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L28)
 
 ___
 
@@ -275,7 +275,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:93](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L93)
+[src/types/route-requests.ts:93](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L93)
 
 ___
 
@@ -285,7 +285,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:78](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L78)
+[src/types/route-requests.ts:78](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L78)
 
 ___
 
@@ -295,7 +295,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:15](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L15)
+[src/types/models.ts:15](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L15)
 
 ___
 
@@ -314,7 +314,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:86](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L86)
+[src/types/route-requests.ts:86](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L86)
 
 ___
 
@@ -324,7 +324,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:187](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L187)
+[src/types/models.ts:187](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L187)
 
 ___
 
@@ -334,7 +334,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:69](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L69)
+[src/types/models.ts:69](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L69)
 
 ___
 
@@ -344,7 +344,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:9](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L9)
+[src/types/models.ts:9](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L9)
 
 ___
 
@@ -354,7 +354,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:14](https://github.com/seamapi/javascript/blob/main/src/types/models.ts#L14)
+[src/types/models.ts:14](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L14)
 
 ___
 
@@ -364,7 +364,7 @@ ___
 
 #### Defined in
 
-[src/types/webhook-events.ts:10](https://github.com/seamapi/javascript/blob/main/src/types/webhook-events.ts#L10)
+[src/types/webhook-events.ts:10](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/webhook-events.ts#L10)
 
 ___
 
@@ -380,7 +380,7 @@ ___
 
 #### Defined in
 
-[src/types/globals.ts:7](https://github.com/seamapi/javascript/blob/main/src/types/globals.ts#L7)
+[src/types/globals.ts:7](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L7)
 
 ___
 
@@ -396,7 +396,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:101](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L101)
+[src/types/route-requests.ts:101](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L101)
 
 ___
 
@@ -412,7 +412,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:97](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L97)
+[src/types/route-requests.ts:97](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L97)
 
 ## Functions
 
@@ -432,4 +432,4 @@ ___
 
 #### Defined in
 
-[src/client.ts:26](https://github.com/seamapi/javascript/blob/main/src/client.ts#L26)
+[src/client.ts:26](https://github.com/seamapi/seamapi-javascript/blob/main/src/client.ts#L26)

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -238,19 +238,15 @@ export abstract class Routes {
         url: "/access_codes/get",
         params,
       }),
-    create: (async (params: AccessCodeCreateRequest) => {
-      const action =
-        await this.createActionAttemptAndWait<"CREATE_ACCESS_CODE">({
-          url: "/access_codes/create",
-          method: "POST",
-          data: params,
-        })
-
-      return action.access_code
-    }) as {
-      (params: AccessCodeCreateOngoingRequest): Promise<OngoingAccessCode>
-      (params: AccessCodeCreateScheduledRequest): Promise<TimeBoundAccessCode>
-    },
+    create: async (params: AccessCodeCreateRequest) =>
+      (await this.makeRequest({
+        url: "/access_codes/create",
+        method: "POST",
+        data: params,
+      })) as {
+        (params: AccessCodeCreateOngoingRequest): Promise<OngoingAccessCode>
+        (params: AccessCodeCreateScheduledRequest): Promise<TimeBoundAccessCode>
+      },
 
     // We can't narrow the return type here like we do with create because we're given partial input
     update: async (


### PR DESCRIPTION
- Add tests
- Usage example for readme (#4)
- Add test dependencies
- Generate JSON schema
- Update test config
- Rename response
- Run test workflow on push
- Check out submodules
- Use HTTP instead of SSH remote
- Update workflow
- Fix types for tests
- Increase test timeout
- skip ci: remove test
- list and get methods added for connected accounts
- fix
- Add dispatch workflow
- Run on push and PRs
- chore(release): 1.1.1 [skip ci]
- fix: update typings
- chore(release): 1.1.2 [skip ci]
- feat: add support for scheduled codes
- chore(release): 1.2.0 [skip ci]
- fix: update README
- fix: format code better
- chore(release): 1.2.1 [skip ci]
- fix: usage example
- chore(release): 1.2.2 [skip ci]
- feat: also output ESM, add CJS wrapper
- chore(release): 1.3.0 [skip ci]
- fix: update response type
- chore(release): 1.3.1 [skip ci]
- Update package.json
- chore(release): 1.3.2 [skip ci]
- await action attempts, return important seam object from endpoints
- switch to ssh cloning of submodule
- fixes based on testing
- update tests submodule
- fix access code querying, update readme
- BREAKING CHANGE: commit to fix release, fix README header
- update readme to attempt release
- last try at major release
- chore(release): 2.0.0 [skip ci]
- remove log line
- fix action attempt failures not throwing
- Add CLI framework & handlers for connected accounts, action attempts
- chore(release): 2.0.1 [skip ci]
- Refactor into separate files
- Add handler for access-codes
- Add handler for connect webview
- Add handlers for devices and locks
- Add handler for workspaces
- Tighten types
- Set up packaging
- Update README
- Split off entry point
- Build standalone binaries during release
- chore(release): 2.1.0 [skip ci]
- Import commands directly to support bundling
- Add bundle for browser
- Fix formatting
- Add shim for process.stdout.write
- Add export so both downstream Webpack and TS are happy
- Wait for command to execute, add intro to help message
- Fix doc references
- Trim command prefix
- chore(release): 2.2.0 [skip ci]
- Fix cache dir for CI builds
- feat: bump version
- chore(release): 2.3.0 [skip ci]
- fix: move typed-emitter to prod dependencies
- chore(release): 2.3.1 [skip ci]
- Update tests
- fix: clean up types
- chore(release): 2.3.2 [skip ci]
- support SEAM_API_URL env var in seam client initialization
- chore(release): 2.3.3 [skip ci]
- support for --workspace-id and --endpoint, change constructor params to options object
- revert version change
- improve browser cli options
- allow workspace id and endpoint flags in cli
- Update src/cli/browser.ts
- fix prettier
- execute command shouldn't pass undefined to allow defaults to be adopted
- chore(release): 2.4.0 [skip ci]
- fix: Introduction of `devices.update` (#19)
- chore(release): 2.4.1 [skip ci]
- Fix test dispatch?
- Use ref
- Throw custom error on malformed input
- Trigger workflow dispatch?
- Update names
- Trigger workflow dispatch?
- Trigger workflow dispatch?
- Fix workflow ref?
- chore(release): 2.5.0 [skip ci]
- fix: update type
- chore(release): 2.5.1 [skip ci]
- Add support for receiving webhooks
- chore(release): 2.6.0 [skip ci]
- Handle basic login flow
- Add 2FA support
- Rename, better error handling
- Use type package
- Fix package reference
- Rename dependency
- Add separate login command
- chore(release): 2.7.0 [skip ci]
- feat: add request ID to thrown errors
- chore(release): 2.8.0 [skip ci]
- feat: support getting a device by name
- chore(release): 3.0.0 [skip ci]
- Better formatting of validation errors
- Add validation error to message
- chore(release): 3.1.0 [skip ci]
- Remove test submodule
- Add tests
- Add test workflow
- Type fixes
- Fix broken "some examples" readme link
- Cache dependencies in workflow
- Pre-pull Seam Connect image
- Use TypeScript for AVA worker
- Parallelize seeding
- Don't need to wait for device anymore
- Bump actions/setup-node version
- feat: handle redirect panes
- fix: build script
- fix: pre-commit hook
- chore(release): 3.2.0 [skip ci]
- Add user agent
- chore(release): 3.3.0 [skip ci]
- Pin Svix fixture version and run migrations
- TEST: debug testcontainers
- Check out correct commit?
- Remove debug
- feat: Add filters to Devices List (#44)
- chore(release): 4.0.0 [skip ci]
- feat: Add accessCodes.update (#46)
- chore(release): 4.1.0 [skip ci]
- feat: Implemented webhooks endpoints (#47)
- chore(release): 4.2.0 [skip ci]
- Fix test
- feat: Add request retries (#43)
- chore(release): 4.3.0 [skip ci]
- fix: bump seamapi-types
- chore(release): 4.3.1 [skip ci]
- feat: add events list request (#48)
- chore(release): 4.4.0 [skip ci]
- fix: device typings
- chore(release): 4.4.1 [skip ci]
- feat: allow passing custom Axios options
- chore(release): 4.5.0 [skip ci]
- Use ghcr.io
- Fix org name
- Login after checkout?
- Login with bot token
- fix: Add `has_keypad` property
- chore(release): 4.6.0 [skip ci]
- fix #66: Adjust Docker container reference
- chore(release): 4.6.1 [skip ci]
- fix #62: Implement `devices.delete`
- chore(release): 4.7.0 [skip ci]
- fix #55: Implement `devices.update`
- chore(release): 4.8.0 [skip ci]
- fix #61: Implement `access_codes.get`
- chore(release): 4.9.0 [skip ci]
- fix #54: Allow getting a ConnectedAccount via email
- fix: Add `manufacturer` property to `LockProperties`
- fix: Add `manufacturer` prop to `LockProperties`
- chore(release): 4.10.0 [skip ci]
- fix: Move `UserIdentifier` above `ConnectedAccount`
- fix: Add test for getting `ConnectedAccount` by ID
- chore(release): 4.11.0 [skip ci]
- fix #53: Implement `connected_accounts.delete`
- fix #73: Implement `connect_webviews.delete`
- chore(release): 4.12.0 [skip ci]
- fix: Type error and rebuild docs
- chore(release): 4.13.0 [skip ci]
- Skiptest until seam connect issue resolved (#80)
- fixes #100
