### PR TITLE
Improvements to client session methods 

### DIFF
--- a/docs/classes/Seam.md
+++ b/docs/classes/Seam.md
@@ -51,7 +51,7 @@ Routes.constructor
 
 #### Defined in
 
-[src/seam-connect/client.ts:65](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L65)
+[src/seam-connect/client.ts:58](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L58)
 
 ## Properties
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[src/seam-connect/client.ts:63](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L63)
+[src/seam-connect/client.ts:56](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L56)
 
 ___
 
@@ -324,7 +324,7 @@ Routes.makeRequest
 
 #### Defined in
 
-[src/seam-connect/client.ts:100](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L100)
+[src/seam-connect/client.ts:93](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L93)
 
 ___
 
@@ -349,4 +349,4 @@ ___
 
 #### Defined in
 
-[src/seam-connect/client.ts:106](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L106)
+[src/seam-connect/client.ts:99](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L99)

--- a/docs/classes/Seam.md
+++ b/docs/classes/Seam.md
@@ -330,13 +330,18 @@ ___
 
 ### getClientSessionToken
 
-▸ `Static` **getClientSessionToken**(`ops`): `Promise`<[`APIResponse`](../modules.md#apiresponse)<[`ClientSessionResponse`](../interfaces/ClientSessionResponse.md)\>\>
+▸ `Static` **getClientSessionToken**(`options`): `Promise`<[`APIResponse`](../modules.md#apiresponse)<[`ClientSessionResponse`](../interfaces/ClientSessionResponse.md)\>\>
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `ops` | `CSTParams` |
+| `options` | `Object` |
+| `options.apiKey?` | `string` |
+| `options.endpoint?` | `string` |
+| `options.publishableKey?` | `string` |
+| `options.userIdentifierKey` | `string` |
+| `options.workspaceId?` | `string` |
 
 #### Returns
 

--- a/docs/classes/Seam.md
+++ b/docs/classes/Seam.md
@@ -51,7 +51,7 @@ Routes.constructor
 
 #### Defined in
 
-[src/seam-connect/client.ts:64](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L64)
+[src/seam-connect/client.ts:65](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L65)
 
 ## Properties
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[src/seam-connect/client.ts:62](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L62)
+[src/seam-connect/client.ts:63](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L63)
 
 ___
 
@@ -324,7 +324,7 @@ Routes.makeRequest
 
 #### Defined in
 
-[src/seam-connect/client.ts:99](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L99)
+[src/seam-connect/client.ts:100](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L100)
 
 ___
 
@@ -349,4 +349,4 @@ ___
 
 #### Defined in
 
-[src/seam-connect/client.ts:105](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L105)
+[src/seam-connect/client.ts:106](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L106)

--- a/docs/classes/Seam.md
+++ b/docs/classes/Seam.md
@@ -51,7 +51,7 @@ Routes.constructor
 
 #### Defined in
 
-[src/seam-connect/client.ts:102](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L102)
+[src/seam-connect/client.ts:64](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L64)
 
 ## Properties
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[src/seam-connect/client.ts:100](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L100)
+[src/seam-connect/client.ts:62](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L62)
 
 ___
 
@@ -324,7 +324,7 @@ Routes.makeRequest
 
 #### Defined in
 
-[src/seam-connect/client.ts:137](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L137)
+[src/seam-connect/client.ts:99](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L99)
 
 ___
 
@@ -349,4 +349,4 @@ ___
 
 #### Defined in
 
-[src/seam-connect/client.ts:143](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L143)
+[src/seam-connect/client.ts:105](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L105)

--- a/docs/classes/Seam.md
+++ b/docs/classes/Seam.md
@@ -349,4 +349,4 @@ ___
 
 #### Defined in
 
-[src/seam-connect/client.ts:162](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L162)
+[src/seam-connect/client.ts:143](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L143)

--- a/src/seam-connect/client.ts
+++ b/src/seam-connect/client.ts
@@ -58,44 +58,6 @@ export const getSeamClientOptionsWithDefaults = (
   }
 }
 
-const getAuthHeaders = ({
-  clientSessionToken,
-  apiKey,
-  workspaceId,
-}: {
-  clientSessionToken?: string
-  apiKey?: string
-  workspaceId?: string
-}): Record<string, string> => {
-  if (apiKey && clientSessionToken) {
-    throw new Error("You can't use clientSessionToken AND specify apiKey.")
-  }
-
-  if (clientSessionToken) {
-    if (!clientSessionToken.startsWith("seam_cst")) {
-      throw new Error("clientSessionToken must start with seam_cst")
-    }
-    return { "client-session-token": clientSessionToken }
-  }
-
-  if (apiKey) {
-    if (apiKey.startsWith("seam_cst")) {
-      console.warn(
-        "Using API Key as Client Session Token is deprecated. Please use the clientSessionToken option instead."
-      )
-      return { "client-session-token": apiKey }
-    }
-    if (!apiKey.startsWith("seam_at") && workspaceId)
-      throw new Error(
-        "You can't use API Key Authentication AND specify a workspace. Your API Key only works for the workspace it was created in. To use Session Key Authentication with multi-workspace support, contact Seam support."
-      )
-    return { authorization: `Bearer ${apiKey}` }
-  }
-  throw new Error(
-    "Must provide either clientSessionToken or apiKey (API Key or Access Token with Workspace ID)."
-  )
-}
-
 export class Seam extends Routes {
   public client: AxiosInstance
 
@@ -216,4 +178,42 @@ const makeRequest = async <T>(
 
     throw error
   }
+}
+
+const getAuthHeaders = ({
+  clientSessionToken,
+  apiKey,
+  workspaceId,
+}: {
+  clientSessionToken?: string
+  apiKey?: string
+  workspaceId?: string
+}): Record<string, string> => {
+  if (apiKey && clientSessionToken) {
+    throw new Error("You can't use clientSessionToken AND specify apiKey.")
+  }
+
+  if (clientSessionToken) {
+    if (!clientSessionToken.startsWith("seam_cst")) {
+      throw new Error("clientSessionToken must start with seam_cst")
+    }
+    return { "client-session-token": clientSessionToken }
+  }
+
+  if (apiKey) {
+    if (apiKey.startsWith("seam_cst")) {
+      console.warn(
+        "Using API Key as Client Session Token is deprecated. Please use the clientSessionToken option instead."
+      )
+      return { "client-session-token": apiKey }
+    }
+    if (!apiKey.startsWith("seam_at") && workspaceId)
+      throw new Error(
+        "You can't use API Key Authentication AND specify a workspace. Your API Key only works for the workspace it was created in. To use Session Key Authentication with multi-workspace support, contact Seam support."
+      )
+    return { authorization: `Bearer ${apiKey}` }
+  }
+  throw new Error(
+    "Must provide either clientSessionToken or apiKey (API Key or Access Token with Workspace ID)."
+  )
 }

--- a/src/seam-connect/client.ts
+++ b/src/seam-connect/client.ts
@@ -38,12 +38,13 @@ export interface SeamClientOptions {
 export const getSeamClientOptionsWithDefaults = (
   apiKeyOrOptions?: string | SeamClientOptions
 ): SeamClientOptions => {
-  let seamClientDefaults: SeamClientOptions = {}
+  const defaultEndpoint = "https://connect.getseam.com"
+  let seamClientDefaults: SeamClientOptions = { endpoint: defaultEndpoint }
   try {
     // try to get defaults from environment (for server-side use)
     seamClientDefaults = {
       apiKey: process?.env?.SEAM_API_KEY,
-      endpoint: process?.env?.SEAM_API_URL || "https://connect.getseam.com",
+      endpoint: process?.env?.SEAM_API_URL ?? defaultEndpoint,
       workspaceId: process?.env?.SEAM_WORKSPACE_ID,
     }
   } catch (error) {

--- a/src/seam-connect/client.ts
+++ b/src/seam-connect/client.ts
@@ -159,24 +159,28 @@ export class Seam extends Routes {
     }
   }
 
-  static async getClientSessionToken(
-    ops: CSTParams
-  ): Promise<APIResponse<ClientSessionResponse>> {
+  static async getClientSessionToken(options: {
+    publishableKey?: string
+    userIdentifierKey: string
+    endpoint?: string
+    workspaceId?: string
+    apiKey?: string
+  }): Promise<APIResponse<ClientSessionResponse>> {
     const { apiKey, endpoint, axiosOptions } =
-      getSeamClientOptionsWithDefaults(ops)
+      getSeamClientOptionsWithDefaults(options)
     let headers: AxiosRequestHeaders = {
       ...axiosOptions?.headers,
     }
 
-    if (ops.publishableKey?.startsWith("seam_pk")) {
+    if (options.publishableKey?.startsWith("seam_pk")) {
       // frontend mode
-      headers["seam-publishable-key"] = ops.publishableKey
+      headers["seam-publishable-key"] = options.publishableKey
     } else if (apiKey?.startsWith("seam_")) {
       // backend mode
       headers["seam-api-key"] = apiKey
     }
-    if (ops.userIdentifierKey) {
-      headers["seam-user-identifier-key"] = ops.userIdentifierKey
+    if (options.userIdentifierKey) {
+      headers["seam-user-identifier-key"] = options.userIdentifierKey
     } else {
       throw new Error("userIdentifierKey is required")
     }
@@ -203,12 +207,4 @@ export class Seam extends Routes {
       )
     }
   }
-}
-
-type CSTParams = {
-  publishableKey?: string
-  userIdentifierKey: string
-  endpoint?: string
-  workspaceId?: string
-  apiKey?: string
 }

--- a/src/seam-connect/client.ts
+++ b/src/seam-connect/client.ts
@@ -38,18 +38,11 @@ export interface SeamClientOptions {
 export const getSeamClientOptionsWithDefaults = (
   apiKeyOrOptions?: string | SeamClientOptions
 ): SeamClientOptions => {
-  const defaultEndpoint = "https://connect.getseam.com"
-  let seamClientDefaults: SeamClientOptions = { endpoint: defaultEndpoint }
-  try {
-    // try to get defaults from environment (for server-side use)
-    seamClientDefaults = {
-      apiKey: process?.env?.SEAM_API_KEY,
-      endpoint: process?.env?.SEAM_API_URL ?? defaultEndpoint,
-      workspaceId: process?.env?.SEAM_WORKSPACE_ID,
-    }
-  } catch (error) {
-    // we are in a browser, so use the apiKeyOrOptions
-    // do nothing
+  const seamClientDefaults = {
+    apiKey: globalThis?.process?.env?.SEAM_API_KEY ?? undefined,
+    endpoint:
+      globalThis?.process?.env?.SEAM_API_URL ?? "https://connect.getseam.com",
+    workspaceId: globalThis?.process?.env?.SEAM_WORKSPACE_ID ?? undefined,
   }
   if (typeof apiKeyOrOptions === "string") {
     // for both browser and server, if apiKeyOrOptions is a string, use it as the apiKey, and merge with defaults


### PR DESCRIPTION
- [Normalize getClientSessionToken options type](https://github.com/seamapi/javascript/pull/191/commits/37cc03f8212cd942625329d381bbd6cc4bebe606): Removes type to bring options into function signature and uses non-abbreviated arg name.
- [feat: Add checks for keys on getClientSessionToken](https://github.com/seamapi/javascript/pull/191/commits/fe72bad584d53323ffe26a2e10a38ae854189eaa): Throw error if keys prefix does not match expected prefix.
- [feat: Reuse makeRequest](https://github.com/seamapi/javascript/pull/191/commits/2bd1a40882ae5755c92131f1c449990d99c358f5): https://github.com/seamapi/javascript/issues/184
- [Move getAuthHeaders down](https://github.com/seamapi/javascript/pull/191/commits/cb8c00e526dbdb15e1c334c65ec6e7d776250141): Just move the helper below the caller.
- [fix: Use correct default endpoint in browser](https://github.com/seamapi/javascript/pull/191/commits/783ef7d32d97bc1b6b281e3da7bb949f330e7bca): Important fix as the default endpoint was not being used by the client!
- [Use globalThis to simplify default options](https://github.com/seamapi/javascript/pull/191/commits/8a26dd74d81cc30971fc47a3adabcc51a2184e6d)