### PR TITLE
fix: don't consider JWT tokens as API Key authentication values

### DIFF
--- a/src/seam-connect/client.ts
+++ b/src/seam-connect/client.ts
@@ -148,6 +148,11 @@ export class Seam extends Routes {
   }
 }
 
+const isValueUsedForAPIKeyAuthentication = (apiKey: string) =>
+  !apiKey.startsWith("seam_at") &&
+  /** Exclude JWT tokens as well */
+  !apiKey.startsWith("ey")
+
 const makeRequest = async <T>(
   client: Axios,
   request: AxiosRequestConfig
@@ -201,7 +206,7 @@ const getAuthHeaders = ({
       )
       return { "client-session-token": apiKey }
     }
-    if (!apiKey.startsWith("seam_at") && workspaceId)
+    if (isValueUsedForAPIKeyAuthentication(apiKey) && workspaceId)
       throw new Error(
         "You can't use API Key Authentication AND specify a workspace. Your API Key only works for the workspace it was created in. To use Session Key Authentication with multi-workspace support, contact Seam support."
       )


### PR DESCRIPTION
This condition was added here to support Seam components a couple weeks ago, but it's breaking when running console locally and authenticating using a JWT:
https://github.com/seamapi/javascript/pull/176/files#diff-390def49f38a64a5323319b9db4429b0e978f6204cd6735e8b516c9d943851fdR84-R86

By expanding the check to allow strings that start with `ey` through, it should work for JWTs again