### PR TITLE
fix: Access code errors and warnings are non-optional

### DIFF
--- a/docs/interfaces/AccessCodeBase.md
+++ b/docs/interfaces/AccessCodeBase.md
@@ -58,7 +58,7 @@ ___
 
 ### errors
 
-• `Optional` **errors**: [`SeamError`](SeamError.md)[]
+• **errors**: [`SeamError`](SeamError.md)[]
 
 #### Defined in
 
@@ -108,7 +108,7 @@ ___
 
 ### warnings
 
-• `Optional` **warnings**: [`SeamWarning`](SeamWarning.md)[]
+• **warnings**: [`SeamWarning`](SeamWarning.md)[]
 
 #### Defined in
 

--- a/docs/interfaces/ManagedAccessCodeBase.md
+++ b/docs/interfaces/ManagedAccessCodeBase.md
@@ -84,7 +84,7 @@ ___
 
 ### errors
 
-• `Optional` **errors**: [`SeamError`](SeamError.md)[]
+• **errors**: [`SeamError`](SeamError.md)[]
 
 #### Inherited from
 
@@ -164,7 +164,7 @@ ___
 
 ### warnings
 
-• `Optional` **warnings**: [`SeamWarning`](SeamWarning.md)[]
+• **warnings**: [`SeamWarning`](SeamWarning.md)[]
 
 #### Inherited from
 

--- a/docs/interfaces/OngoingAccessCode.md
+++ b/docs/interfaces/OngoingAccessCode.md
@@ -97,7 +97,7 @@ ___
 
 ### errors
 
-• `Optional` **errors**: [`SeamError`](SeamError.md)[]
+• **errors**: [`SeamError`](SeamError.md)[]
 
 #### Inherited from
 
@@ -201,7 +201,7 @@ ___
 
 ### warnings
 
-• `Optional` **warnings**: [`SeamWarning`](SeamWarning.md)[]
+• **warnings**: [`SeamWarning`](SeamWarning.md)[]
 
 #### Inherited from
 

--- a/docs/interfaces/TimeBoundAccessCode.md
+++ b/docs/interfaces/TimeBoundAccessCode.md
@@ -110,7 +110,7 @@ ___
 
 ### errors
 
-• `Optional` **errors**: [`SeamError`](SeamError.md)[]
+• **errors**: [`SeamError`](SeamError.md)[]
 
 #### Inherited from
 
@@ -234,7 +234,7 @@ ___
 
 ### warnings
 
-• `Optional` **warnings**: [`SeamWarning`](SeamWarning.md)[]
+• **warnings**: [`SeamWarning`](SeamWarning.md)[]
 
 #### Inherited from
 

--- a/docs/interfaces/UnmanagedAccessCodeBase.md
+++ b/docs/interfaces/UnmanagedAccessCodeBase.md
@@ -84,7 +84,7 @@ ___
 
 ### errors
 
-• `Optional` **errors**: [`SeamError`](SeamError.md)[]
+• **errors**: [`SeamError`](SeamError.md)[]
 
 #### Inherited from
 
@@ -164,7 +164,7 @@ ___
 
 ### warnings
 
-• `Optional` **warnings**: [`SeamWarning`](SeamWarning.md)[]
+• **warnings**: [`SeamWarning`](SeamWarning.md)[]
 
 #### Inherited from
 

--- a/docs/interfaces/UnmanagedOngoingAccessCode.md
+++ b/docs/interfaces/UnmanagedOngoingAccessCode.md
@@ -85,7 +85,7 @@ ___
 
 ### errors
 
-• `Optional` **errors**: [`SeamError`](SeamError.md)[]
+• **errors**: [`SeamError`](SeamError.md)[]
 
 #### Inherited from
 
@@ -179,7 +179,7 @@ ___
 
 ### warnings
 
-• `Optional` **warnings**: [`SeamWarning`](SeamWarning.md)[]
+• **warnings**: [`SeamWarning`](SeamWarning.md)[]
 
 #### Inherited from
 

--- a/docs/interfaces/UnmanagedTimeBoundAccessCode.md
+++ b/docs/interfaces/UnmanagedTimeBoundAccessCode.md
@@ -97,7 +97,7 @@ ___
 
 ### errors
 
-• `Optional` **errors**: [`SeamError`](SeamError.md)[]
+• **errors**: [`SeamError`](SeamError.md)[]
 
 #### Inherited from
 
@@ -201,7 +201,7 @@ ___
 
 ### warnings
 
-• `Optional` **warnings**: [`SeamWarning`](SeamWarning.md)[]
+• **warnings**: [`SeamWarning`](SeamWarning.md)[]
 
 #### Inherited from
 

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -308,8 +308,8 @@ export interface AccessCodeBase {
   is_backup?: boolean
   pulled_backup_access_code_id?: string | null
   is_backup_access_code_available: boolean
-  errors?: SeamError[]
-  warnings?: SeamWarning[]
+  errors: SeamError[]
+  warnings: SeamWarning[]
 }
 
 export interface ManagedAccessCodeBase extends AccessCodeBase {


### PR DESCRIPTION
Merging this separately from https://github.com/seamapi/javascript/pull/228