### PR TITLE
fix: Always use local semantic-release

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,7 +23,6 @@ runs:
       uses: actions/setup-node@v3
       if: inputs.install_dependencies == 'true'
       with:
-        cache: npm
         node-version: ${{ inputs.node_version }}
         registry-url: ${{ inputs.registry_url }}
     - name: Setup Node.js without cache

--- a/.github/workflows/npm-semantic-release.yml
+++ b/.github/workflows/npm-semantic-release.yml
@@ -12,16 +12,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: "18.x"
-          cache: "yarn"
-      - name: Install dependencies
-        run: yarn install
+        uses: actions/checkout@v3
+      - name: Setup
+        uses: ./.github/actions/setup
       - name: Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
-        run: npx semantic-release
+        run: yarn run semantic-release

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "build:docs": "typedoc",
     "build:json-response-schemas": "ts-json-schema-generator --path src/types/route-responses.ts -o src/types/route-responses.generated.json && ts-json-schema-generator --path src/types/models.ts -o src/types/models.generated.json",
     "build": "npm run build:json-response-schemas && npm run build:package && npm run build:docs",
+    "semantic-release": "semantic-release",
     "pack:cli": "pkg -c package.json dist/cli/entry.js",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",


### PR DESCRIPTION
Something with the cache + npx on GH actions is breaking. We should be using the local version via what is installed with yarn instead anyway.