### PR TITLE
fix: Use npx for semantic-release

### DIFF
--- a/.github/workflows/npm-semantic-release.yml
+++ b/.github/workflows/npm-semantic-release.yml
@@ -19,4 +19,4 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
-        run: yarn run semantic-release
+        run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "build:docs": "typedoc",
     "build:json-response-schemas": "ts-json-schema-generator --path src/types/route-responses.ts -o src/types/route-responses.generated.json && ts-json-schema-generator --path src/types/models.ts -o src/types/models.generated.json",
     "build": "npm run build:json-response-schemas && npm run build:package && npm run build:docs",
-    "semantic-release": "semantic-release",
     "pack:cli": "pkg -c package.json dist/cli/entry.js",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",


### PR DESCRIPTION
Now SR is saying the npm token is invalid. Going back to the npx method to see if that actually is related to this issue.