### PR TITLE
fix: Use last known working workflow for npm-semantic-release

### DIFF
--- a/.github/workflows/npm-prettier.yml
+++ b/.github/workflows/npm-prettier.yml
@@ -15,6 +15,5 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 18
-          cache: "yarn"
       - run: yarn install
       - run: yarn format:check

--- a/.github/workflows/npm-semantic-release.yml
+++ b/.github/workflows/npm-semantic-release.yml
@@ -12,9 +12,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup
-        uses: ./.github/actions/setup
+        uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18.x"
+      - name: Install dependencies
+        run: yarn install
       - name: Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -62,7 +62,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 18
-          cache: "yarn"
 
       - run: yarn install --frozen-lockfile
       - run: yarn test -T 3m


### PR DESCRIPTION
This is the last known working semantic release workflow but without the cache options in any of the steps as that was randomly breaking the build.