### PR TITLE
Add missing client session methods

### DIFF
--- a/docs/classes/Seam.md
+++ b/docs/classes/Seam.md
@@ -86,7 +86,7 @@ Routes.accessCodes
 
 #### Defined in
 
-[src/seam-connect/routes.ts:310](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L310)
+[src/seam-connect/routes.ts:312](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L312)
 
 ___
 
@@ -106,7 +106,7 @@ Routes.actionAttempts
 
 #### Defined in
 
-[src/seam-connect/routes.ts:449](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L449)
+[src/seam-connect/routes.ts:451](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L451)
 
 ___
 
@@ -131,6 +131,7 @@ ___
 | `create` | (`params`: [`ClientSessionsCreateRequest`](../modules.md#clientsessionscreaterequest)) => `Promise`<[`ClientSession`](../interfaces/ClientSession.md)\> |
 | `delete` | (`params`: [`ClientSessionsDeleteRequest`](../modules.md#clientsessionsdeleterequest)) => `Promise`<{ `ok`: ``true``  }\> |
 | `getOrCreate` | (`params`: [`ClientSessionsCreateRequest`](../modules.md#clientsessionscreaterequest)) => `Promise`<[`ClientSession`](../interfaces/ClientSession.md)\> |
+| `list` | (`params`: [`ClientSessionsListRequest`](../modules.md#clientsessionslistrequest)) => `Promise`<[`ClientSession`](../interfaces/ClientSession.md)[]\> |
 
 #### Inherited from
 
@@ -138,7 +139,7 @@ Routes.clientSessions
 
 #### Defined in
 
-[src/seam-connect/routes.ts:515](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L515)
+[src/seam-connect/routes.ts:517](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L517)
 
 ___
 
@@ -161,7 +162,7 @@ Routes.connectWebviews
 
 #### Defined in
 
-[src/seam-connect/routes.ts:278](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L278)
+[src/seam-connect/routes.ts:280](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L280)
 
 ___
 
@@ -183,7 +184,7 @@ Routes.connectedAccounts
 
 #### Defined in
 
-[src/seam-connect/routes.ts:424](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L424)
+[src/seam-connect/routes.ts:426](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L426)
 
 ___
 
@@ -203,7 +204,7 @@ Routes.deviceModels
 
 #### Defined in
 
-[src/seam-connect/routes.ts:542](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L542)
+[src/seam-connect/routes.ts:550](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L550)
 
 ___
 
@@ -230,7 +231,7 @@ Routes.devices
 
 #### Defined in
 
-[src/seam-connect/routes.ts:213](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L213)
+[src/seam-connect/routes.ts:215](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L215)
 
 ___
 
@@ -251,7 +252,7 @@ Routes.events
 
 #### Defined in
 
-[src/seam-connect/routes.ts:260](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L260)
+[src/seam-connect/routes.ts:262](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L262)
 
 ___
 
@@ -274,7 +275,7 @@ Routes.locks
 
 #### Defined in
 
-[src/seam-connect/routes.ts:178](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L178)
+[src/seam-connect/routes.ts:180](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L180)
 
 ___
 
@@ -297,7 +298,7 @@ Routes.noiseThresholds
 
 #### Defined in
 
-[src/seam-connect/routes.ts:459](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L459)
+[src/seam-connect/routes.ts:461](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L461)
 
 ___
 
@@ -326,7 +327,7 @@ Routes.thermostats
 
 #### Defined in
 
-[src/seam-connect/routes.ts:562](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L562)
+[src/seam-connect/routes.ts:570](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L570)
 
 ___
 
@@ -349,7 +350,7 @@ Routes.webhooks
 
 #### Defined in
 
-[src/seam-connect/routes.ts:490](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L490)
+[src/seam-connect/routes.ts:492](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L492)
 
 ___
 
@@ -371,7 +372,7 @@ Routes.workspaces
 
 #### Defined in
 
-[src/seam-connect/routes.ts:162](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L162)
+[src/seam-connect/routes.ts:164](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L164)
 
 ## Methods
 

--- a/docs/classes/Seam.md
+++ b/docs/classes/Seam.md
@@ -86,7 +86,7 @@ Routes.accessCodes
 
 #### Defined in
 
-[src/seam-connect/routes.ts:308](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L308)
+[src/seam-connect/routes.ts:309](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L309)
 
 ___
 
@@ -106,7 +106,7 @@ Routes.actionAttempts
 
 #### Defined in
 
-[src/seam-connect/routes.ts:447](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L447)
+[src/seam-connect/routes.ts:448](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L448)
 
 ___
 
@@ -137,7 +137,7 @@ Routes.clientSessions
 
 #### Defined in
 
-[src/seam-connect/routes.ts:513](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L513)
+[src/seam-connect/routes.ts:514](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L514)
 
 ___
 
@@ -160,7 +160,7 @@ Routes.connectWebviews
 
 #### Defined in
 
-[src/seam-connect/routes.ts:276](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L276)
+[src/seam-connect/routes.ts:277](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L277)
 
 ___
 
@@ -182,7 +182,7 @@ Routes.connectedAccounts
 
 #### Defined in
 
-[src/seam-connect/routes.ts:422](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L422)
+[src/seam-connect/routes.ts:423](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L423)
 
 ___
 
@@ -202,7 +202,7 @@ Routes.deviceModels
 
 #### Defined in
 
-[src/seam-connect/routes.ts:528](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L528)
+[src/seam-connect/routes.ts:535](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L535)
 
 ___
 
@@ -229,7 +229,7 @@ Routes.devices
 
 #### Defined in
 
-[src/seam-connect/routes.ts:211](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L211)
+[src/seam-connect/routes.ts:212](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L212)
 
 ___
 
@@ -250,7 +250,7 @@ Routes.events
 
 #### Defined in
 
-[src/seam-connect/routes.ts:258](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L258)
+[src/seam-connect/routes.ts:259](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L259)
 
 ___
 
@@ -273,7 +273,7 @@ Routes.locks
 
 #### Defined in
 
-[src/seam-connect/routes.ts:176](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L176)
+[src/seam-connect/routes.ts:177](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L177)
 
 ___
 
@@ -296,7 +296,7 @@ Routes.noiseThresholds
 
 #### Defined in
 
-[src/seam-connect/routes.ts:457](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L457)
+[src/seam-connect/routes.ts:458](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L458)
 
 ___
 
@@ -325,7 +325,7 @@ Routes.thermostats
 
 #### Defined in
 
-[src/seam-connect/routes.ts:548](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L548)
+[src/seam-connect/routes.ts:555](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L555)
 
 ___
 
@@ -348,7 +348,7 @@ Routes.webhooks
 
 #### Defined in
 
-[src/seam-connect/routes.ts:488](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L488)
+[src/seam-connect/routes.ts:489](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L489)
 
 ___
 
@@ -370,7 +370,7 @@ Routes.workspaces
 
 #### Defined in
 
-[src/seam-connect/routes.ts:160](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L160)
+[src/seam-connect/routes.ts:161](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L161)
 
 ## Methods
 
@@ -406,7 +406,7 @@ ___
 
 ### getClientSessionToken
 
-▸ `Static` **getClientSessionToken**(`options`): `Promise`<[`APIResponse`](../modules.md#apiresponse)<[`ClientSessionsResponse`](../modules.md#clientsessionsresponse)\>\>
+▸ `Static` **getClientSessionToken**(`options`): `Promise`<[`APIResponse`](../modules.md#apiresponse)<[`ClientSessionsCreateResponse`](../modules.md#clientsessionscreateresponse)\>\>
 
 #### Parameters
 
@@ -421,7 +421,7 @@ ___
 
 #### Returns
 
-`Promise`<[`APIResponse`](../modules.md#apiresponse)<[`ClientSessionsResponse`](../modules.md#clientsessionsresponse)\>\>
+`Promise`<[`APIResponse`](../modules.md#apiresponse)<[`ClientSessionsCreateResponse`](../modules.md#clientsessionscreateresponse)\>\>
 
 #### Defined in
 

--- a/docs/classes/Seam.md
+++ b/docs/classes/Seam.md
@@ -86,7 +86,7 @@ Routes.accessCodes
 
 #### Defined in
 
-[src/seam-connect/routes.ts:309](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L309)
+[src/seam-connect/routes.ts:310](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L310)
 
 ___
 
@@ -106,7 +106,7 @@ Routes.actionAttempts
 
 #### Defined in
 
-[src/seam-connect/routes.ts:448](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L448)
+[src/seam-connect/routes.ts:449](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L449)
 
 ___
 
@@ -129,6 +129,7 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `create` | (`params`: [`ClientSessionsCreateRequest`](../modules.md#clientsessionscreaterequest)) => `Promise`<[`ClientSession`](../interfaces/ClientSession.md)\> |
+| `delete` | (`params`: [`ClientSessionsDeleteRequest`](../modules.md#clientsessionsdeleterequest)) => `Promise`<{ `ok`: ``true``  }\> |
 | `getOrCreate` | (`params`: [`ClientSessionsCreateRequest`](../modules.md#clientsessionscreaterequest)) => `Promise`<[`ClientSession`](../interfaces/ClientSession.md)\> |
 
 #### Inherited from
@@ -137,7 +138,7 @@ Routes.clientSessions
 
 #### Defined in
 
-[src/seam-connect/routes.ts:514](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L514)
+[src/seam-connect/routes.ts:515](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L515)
 
 ___
 
@@ -160,7 +161,7 @@ Routes.connectWebviews
 
 #### Defined in
 
-[src/seam-connect/routes.ts:277](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L277)
+[src/seam-connect/routes.ts:278](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L278)
 
 ___
 
@@ -182,7 +183,7 @@ Routes.connectedAccounts
 
 #### Defined in
 
-[src/seam-connect/routes.ts:423](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L423)
+[src/seam-connect/routes.ts:424](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L424)
 
 ___
 
@@ -202,7 +203,7 @@ Routes.deviceModels
 
 #### Defined in
 
-[src/seam-connect/routes.ts:535](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L535)
+[src/seam-connect/routes.ts:542](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L542)
 
 ___
 
@@ -229,7 +230,7 @@ Routes.devices
 
 #### Defined in
 
-[src/seam-connect/routes.ts:212](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L212)
+[src/seam-connect/routes.ts:213](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L213)
 
 ___
 
@@ -250,7 +251,7 @@ Routes.events
 
 #### Defined in
 
-[src/seam-connect/routes.ts:259](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L259)
+[src/seam-connect/routes.ts:260](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L260)
 
 ___
 
@@ -273,7 +274,7 @@ Routes.locks
 
 #### Defined in
 
-[src/seam-connect/routes.ts:177](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L177)
+[src/seam-connect/routes.ts:178](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L178)
 
 ___
 
@@ -296,7 +297,7 @@ Routes.noiseThresholds
 
 #### Defined in
 
-[src/seam-connect/routes.ts:458](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L458)
+[src/seam-connect/routes.ts:459](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L459)
 
 ___
 
@@ -325,7 +326,7 @@ Routes.thermostats
 
 #### Defined in
 
-[src/seam-connect/routes.ts:555](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L555)
+[src/seam-connect/routes.ts:562](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L562)
 
 ___
 
@@ -348,7 +349,7 @@ Routes.webhooks
 
 #### Defined in
 
-[src/seam-connect/routes.ts:489](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L489)
+[src/seam-connect/routes.ts:490](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L490)
 
 ___
 
@@ -370,7 +371,7 @@ Routes.workspaces
 
 #### Defined in
 
-[src/seam-connect/routes.ts:161](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L161)
+[src/seam-connect/routes.ts:162](https://github.com/seamapi/javascript/blob/main/src/seam-connect/routes.ts#L162)
 
 ## Methods
 

--- a/docs/interfaces/ClimateSettingScheduleCreateResponse.md
+++ b/docs/interfaces/ClimateSettingScheduleCreateResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:182](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L182)
+[src/types/route-responses.ts:186](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L186)

--- a/docs/interfaces/ClimateSettingScheduleCreateResponse.md
+++ b/docs/interfaces/ClimateSettingScheduleCreateResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:176](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L176)
+[src/types/route-responses.ts:182](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L182)

--- a/docs/interfaces/ClimateSettingScheduleGetResponse.md
+++ b/docs/interfaces/ClimateSettingScheduleGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:172](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L172)
+[src/types/route-responses.ts:178](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L178)

--- a/docs/interfaces/ClimateSettingScheduleGetResponse.md
+++ b/docs/interfaces/ClimateSettingScheduleGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:178](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L178)
+[src/types/route-responses.ts:182](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L182)

--- a/docs/interfaces/ClimateSettingScheduleUpdateResponse.md
+++ b/docs/interfaces/ClimateSettingScheduleUpdateResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:186](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L186)
+[src/types/route-responses.ts:190](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L190)

--- a/docs/interfaces/ClimateSettingScheduleUpdateResponse.md
+++ b/docs/interfaces/ClimateSettingScheduleUpdateResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:180](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L180)
+[src/types/route-responses.ts:186](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L186)

--- a/docs/interfaces/ClimateSettingSchedulesListResponse.md
+++ b/docs/interfaces/ClimateSettingSchedulesListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:168](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L168)
+[src/types/route-responses.ts:174](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L174)

--- a/docs/interfaces/ClimateSettingSchedulesListResponse.md
+++ b/docs/interfaces/ClimateSettingSchedulesListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:174](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L174)
+[src/types/route-responses.ts:178](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L178)

--- a/docs/interfaces/ThermostatGetResponse.md
+++ b/docs/interfaces/ThermostatGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:163](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L163)
+[src/types/route-responses.ts:169](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L169)

--- a/docs/interfaces/ThermostatGetResponse.md
+++ b/docs/interfaces/ThermostatGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:169](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L169)
+[src/types/route-responses.ts:173](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L173)

--- a/docs/interfaces/ThermostatsListResponse.md
+++ b/docs/interfaces/ThermostatsListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:166](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L166)
+[src/types/route-responses.ts:170](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L170)

--- a/docs/interfaces/ThermostatsListResponse.md
+++ b/docs/interfaces/ThermostatsListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:160](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L160)
+[src/types/route-responses.ts:166](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L166)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -123,7 +123,9 @@
 - [AnyDevice](modules.md#anydevice)
 - [BatteryStatus](modules.md#batterystatus)
 - [ClientSessionsCreateRequest](modules.md#clientsessionscreaterequest)
+- [ClientSessionsCreateResponse](modules.md#clientsessionscreateresponse)
 - [ClientSessionsGetOrCreateRequest](modules.md#clientsessionsgetorcreaterequest)
+- [ClientSessionsGetOrCreateResponse](modules.md#clientsessionsgetorcreateresponse)
 - [ClientSessionsResponse](modules.md#clientsessionsresponse)
 - [ClimateSetting](modules.md#climatesetting)
 - [ClimateSettingSchedule](modules.md#climatesettingschedule)
@@ -418,6 +420,22 @@ ___
 
 ___
 
+### ClientSessionsCreateResponse
+
+Ƭ **ClientSessionsCreateResponse**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `client_session` | [`ClientSession`](interfaces/ClientSession.md) |
+
+#### Defined in
+
+[src/types/route-responses.ts:151](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L151)
+
+___
+
 ### ClientSessionsGetOrCreateRequest
 
 Ƭ **ClientSessionsGetOrCreateRequest**: [`ClientSessionsCreateRequest`](modules.md#clientsessionscreaterequest)
@@ -428,19 +446,25 @@ ___
 
 ___
 
-### ClientSessionsResponse
+### ClientSessionsGetOrCreateResponse
 
-Ƭ **ClientSessionsResponse**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `client_session` | [`ClientSession`](interfaces/ClientSession.md) |
+Ƭ **ClientSessionsGetOrCreateResponse**: [`ClientSessionsCreateResponse`](modules.md#clientsessionscreateresponse)
 
 #### Defined in
 
-[src/types/route-responses.ts:150](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L150)
+[src/types/route-responses.ts:155](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L155)
+
+___
+
+### ClientSessionsResponse
+
+Ƭ **ClientSessionsResponse**: [`ClientSessionsCreateResponse`](modules.md#clientsessionscreateresponse)
+
+**`deprecated`** use ClientSessionsCreateResponse instead
+
+#### Defined in
+
+[src/types/route-responses.ts:158](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L158)
 
 ___
 
@@ -675,7 +699,7 @@ ___
 
 #### Defined in
 
-[src/types/route-responses.ts:154](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L154)
+[src/types/route-responses.ts:160](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L160)
 
 ___
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -127,6 +127,8 @@
 - [ClientSessionsDeleteRequest](modules.md#clientsessionsdeleterequest)
 - [ClientSessionsGetOrCreateRequest](modules.md#clientsessionsgetorcreaterequest)
 - [ClientSessionsGetOrCreateResponse](modules.md#clientsessionsgetorcreateresponse)
+- [ClientSessionsListRequest](modules.md#clientsessionslistrequest)
+- [ClientSessionsListResponse](modules.md#clientsessionslistresponse)
 - [ClientSessionsResponse](modules.md#clientsessionsresponse)
 - [ClimateSetting](modules.md#climatesetting)
 - [ClimateSettingSchedule](modules.md#climatesettingschedule)
@@ -449,7 +451,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:236](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L236)
+[src/types/route-requests.ts:238](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L238)
 
 ___
 
@@ -459,13 +461,39 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:240](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L240)
+[src/types/route-requests.ts:242](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L242)
 
 ___
 
 ### ClientSessionsGetOrCreateResponse
 
 Ƭ **ClientSessionsGetOrCreateResponse**: [`ClientSessionsCreateResponse`](modules.md#clientsessionscreateresponse)
+
+#### Defined in
+
+[src/types/route-responses.ts:159](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L159)
+
+___
+
+### ClientSessionsListRequest
+
+Ƭ **ClientSessionsListRequest**: `Object`
+
+#### Defined in
+
+[src/types/route-requests.ts:236](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L236)
+
+___
+
+### ClientSessionsListResponse
+
+Ƭ **ClientSessionsListResponse**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `client_sessions` | [`ClientSession`](interfaces/ClientSession.md)[] |
 
 #### Defined in
 
@@ -481,7 +509,7 @@ ___
 
 #### Defined in
 
-[src/types/route-responses.ts:158](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L158)
+[src/types/route-responses.ts:162](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L162)
 
 ___
 
@@ -534,7 +562,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:260](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L260)
+[src/types/route-requests.ts:262](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L262)
 
 ___
 
@@ -550,7 +578,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:267](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L267)
+[src/types/route-requests.ts:269](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L269)
 
 ___
 
@@ -567,7 +595,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:255](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L255)
+[src/types/route-requests.ts:257](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L257)
 
 ___
 
@@ -577,7 +605,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:262](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L262)
+[src/types/route-requests.ts:264](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L264)
 
 ___
 
@@ -593,7 +621,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:251](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L251)
+[src/types/route-requests.ts:253](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L253)
 
 ___
 
@@ -700,7 +728,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:242](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L242)
+[src/types/route-requests.ts:244](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L244)
 
 ___
 
@@ -716,7 +744,7 @@ ___
 
 #### Defined in
 
-[src/types/route-responses.ts:160](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L160)
+[src/types/route-responses.ts:164](https://github.com/seamapi/javascript/blob/main/src/types/route-responses.ts#L164)
 
 ___
 
@@ -1024,7 +1052,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:273](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L273)
+[src/types/route-requests.ts:275](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L275)
 
 ___
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -124,6 +124,7 @@
 - [BatteryStatus](modules.md#batterystatus)
 - [ClientSessionsCreateRequest](modules.md#clientsessionscreaterequest)
 - [ClientSessionsCreateResponse](modules.md#clientsessionscreateresponse)
+- [ClientSessionsDeleteRequest](modules.md#clientsessionsdeleterequest)
 - [ClientSessionsGetOrCreateRequest](modules.md#clientsessionsgetorcreaterequest)
 - [ClientSessionsGetOrCreateResponse](modules.md#clientsessionsgetorcreateresponse)
 - [ClientSessionsResponse](modules.md#clientsessionsresponse)
@@ -436,13 +437,29 @@ ___
 
 ___
 
+### ClientSessionsDeleteRequest
+
+Ƭ **ClientSessionsDeleteRequest**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `client_session_id` | `string` |
+
+#### Defined in
+
+[src/types/route-requests.ts:236](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L236)
+
+___
+
 ### ClientSessionsGetOrCreateRequest
 
 Ƭ **ClientSessionsGetOrCreateRequest**: [`ClientSessionsCreateRequest`](modules.md#clientsessionscreaterequest)
 
 #### Defined in
 
-[src/types/route-requests.ts:236](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L236)
+[src/types/route-requests.ts:240](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L240)
 
 ___
 
@@ -517,7 +534,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:256](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L256)
+[src/types/route-requests.ts:260](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L260)
 
 ___
 
@@ -533,7 +550,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:263](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L263)
+[src/types/route-requests.ts:267](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L267)
 
 ___
 
@@ -550,7 +567,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:251](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L251)
+[src/types/route-requests.ts:255](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L255)
 
 ___
 
@@ -560,7 +577,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:258](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L258)
+[src/types/route-requests.ts:262](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L262)
 
 ___
 
@@ -576,7 +593,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:247](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L247)
+[src/types/route-requests.ts:251](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L251)
 
 ___
 
@@ -683,7 +700,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:238](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L238)
+[src/types/route-requests.ts:242](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L242)
 
 ___
 
@@ -1007,7 +1024,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:269](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L269)
+[src/types/route-requests.ts:273](https://github.com/seamapi/javascript/blob/main/src/types/route-requests.ts#L273)
 
 ___
 

--- a/src/seam-connect/routes.ts
+++ b/src/seam-connect/routes.ts
@@ -44,6 +44,7 @@ import {
   NoiseThresholdsUpdateRequest,
   ClientSessionsCreateRequest,
   ClientSessionsGetOrCreateRequest,
+  ClientSessionsListRequest,
   ClientSessionsDeleteRequest,
   UnmanagedAccessCodeConvertToManagedRequest,
   DeviceModelsListRequest,
@@ -85,6 +86,7 @@ import {
   NoiseThresholdsListResponse,
   ClientSessionsCreateResponse,
   ClientSessionsGetOrCreateResponse,
+  ClientSessionsListResponse,
   DeviceModelsListResponse,
   ThermostatsListResponse,
   ThermostatGetResponse,
@@ -531,6 +533,12 @@ export abstract class Routes {
           params,
         }
       ),
+    list: (params: ClientSessionsListRequest) =>
+      this.makeRequestAndFormat<ClientSessionsListResponse>("client_sessions", {
+        url: "/client_sessions/list",
+        method: "GET",
+        params,
+      }),
     delete: (params: ClientSessionsDeleteRequest) =>
       this.makeRequest({
         url: "/client_sessions/delete",

--- a/src/seam-connect/routes.ts
+++ b/src/seam-connect/routes.ts
@@ -82,7 +82,8 @@ import {
   WorkspaceResetSandboxResponse,
   WorkspacesListResponse,
   NoiseThresholdsListResponse,
-  ClientSessionsResponse,
+  ClientSessionsCreateResponse,
+  ClientSessionsGetOrCreateResponse,
   DeviceModelsListResponse,
   ThermostatsListResponse,
   ThermostatGetResponse,
@@ -512,17 +513,23 @@ export abstract class Routes {
 
   public readonly clientSessions = {
     create: (params: ClientSessionsCreateRequest) =>
-      this.makeRequestAndFormat<ClientSessionsResponse>("client_session", {
-        url: "/client_sessions/create",
-        method: "POST",
-        params,
-      }),
+      this.makeRequestAndFormat<ClientSessionsCreateResponse>(
+        "client_session",
+        {
+          url: "/client_sessions/create",
+          method: "POST",
+          params,
+        }
+      ),
     getOrCreate: (params: ClientSessionsGetOrCreateRequest) =>
-      this.makeRequestAndFormat<ClientSessionsResponse>("client_session", {
-        url: "/client_sessions/create",
-        method: "PUT",
-        params,
-      }),
+      this.makeRequestAndFormat<ClientSessionsGetOrCreateResponse>(
+        "client_session",
+        {
+          url: "/client_sessions/create",
+          method: "PUT",
+          params,
+        }
+      ),
   }
 
   public readonly deviceModels = {

--- a/src/seam-connect/routes.ts
+++ b/src/seam-connect/routes.ts
@@ -44,6 +44,7 @@ import {
   NoiseThresholdsUpdateRequest,
   ClientSessionsCreateRequest,
   ClientSessionsGetOrCreateRequest,
+  ClientSessionsDeleteRequest,
   UnmanagedAccessCodeConvertToManagedRequest,
   DeviceModelsListRequest,
   ThermostatUpdateRequest,
@@ -530,6 +531,12 @@ export abstract class Routes {
           params,
         }
       ),
+    delete: (params: ClientSessionsDeleteRequest) =>
+      this.makeRequest({
+        url: "/client_sessions/delete",
+        method: "DELETE",
+        params,
+      }),
   }
 
   public readonly deviceModels = {

--- a/src/types/route-requests.ts
+++ b/src/types/route-requests.ts
@@ -233,6 +233,10 @@ export type ClientSessionsCreateRequest = {
   connected_account_ids?: string[]
 }
 
+export type ClientSessionsDeleteRequest = {
+  client_session_id: string
+}
+
 export type ClientSessionsGetOrCreateRequest = ClientSessionsCreateRequest
 
 export type DeviceModelsListRequest = {

--- a/src/types/route-requests.ts
+++ b/src/types/route-requests.ts
@@ -233,6 +233,8 @@ export type ClientSessionsCreateRequest = {
   connected_account_ids?: string[]
 }
 
+export type ClientSessionsListRequest = {}
+
 export type ClientSessionsDeleteRequest = {
   client_session_id: string
 }

--- a/src/types/route-responses.ts
+++ b/src/types/route-responses.ts
@@ -147,9 +147,15 @@ export type NoiseThresholdsListResponse = {
 }
 
 // Client Sessions
-export type ClientSessionsResponse = {
+
+export type ClientSessionsCreateResponse = {
   client_session: ClientSession
 }
+
+export type ClientSessionsGetOrCreateResponse = ClientSessionsCreateResponse
+
+/** @deprecated use ClientSessionsCreateResponse instead */
+export type ClientSessionsResponse = ClientSessionsCreateResponse
 
 export type DeviceModelsListResponse = {
   device_models: DeviceModel[]

--- a/src/types/route-responses.ts
+++ b/src/types/route-responses.ts
@@ -152,6 +152,10 @@ export type ClientSessionsCreateResponse = {
   client_session: ClientSession
 }
 
+export type ClientSessionsListResponse = {
+  client_sessions: ClientSession[]
+}
+
 export type ClientSessionsGetOrCreateResponse = ClientSessionsCreateResponse
 
 /** @deprecated use ClientSessionsCreateResponse instead */


### PR DESCRIPTION
- [fix: Add properly names client session types](https://github.com/seamapi/javascript/pull/240/commits/8732c0fa9ecc2988e25b6818f16be2e5b31dbb91)
- [feat: Add clientSessions.delete](https://github.com/seamapi/javascript/pull/240/commits/2353bc6a91d8c23f3a01443e1ab48559b8363794)
- [feat: Add clientSessions.list](https://github.com/seamapi/javascript/pull/240/commits/aba7e5feb902d75505015e561c6b641a2d8c658d)