### PR TITLE
Fix Session creation requests: data is expected in the request body

### DIFF
--- a/src/seam-connect/routes.ts
+++ b/src/seam-connect/routes.ts
@@ -515,22 +515,22 @@ export abstract class Routes {
   }
 
   public readonly clientSessions = {
-    create: (params: ClientSessionsCreateRequest) =>
+    create: (data: ClientSessionsCreateRequest) =>
       this.makeRequestAndFormat<ClientSessionsCreateResponse>(
         "client_session",
         {
           url: "/client_sessions/create",
           method: "POST",
-          params,
+          data,
         }
       ),
-    getOrCreate: (params: ClientSessionsGetOrCreateRequest) =>
+    getOrCreate: (data: ClientSessionsGetOrCreateRequest) =>
       this.makeRequestAndFormat<ClientSessionsGetOrCreateResponse>(
         "client_session",
         {
           url: "/client_sessions/create",
           method: "PUT",
-          params,
+          data,
         }
       ),
     list: (params: ClientSessionsListRequest) =>


### PR DESCRIPTION
The API was ignoring the data passed as URL parameters but takes it into account when passed in the body.

https://axios-http.com/docs/req_config
- Axios's `params` sets URL parameters
- What the API seems to be expecting here is the body of the request to contain the data

@razor-x 