### PR TITLE
Use authorization header with client session token

### DIFF
--- a/docs/classes/Seam.md
+++ b/docs/classes/Seam.md
@@ -403,7 +403,7 @@ Routes.makeRequest
 
 #### Defined in
 
-[src/seam-connect/client.ts:107](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L107)
+[src/seam-connect/client.ts:108](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L108)
 
 ___
 
@@ -428,4 +428,4 @@ ___
 
 #### Defined in
 
-[src/seam-connect/client.ts:113](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L113)
+[src/seam-connect/client.ts:114](https://github.com/seamapi/javascript/blob/main/src/seam-connect/client.ts#L114)

--- a/src/seam-connect/client.ts
+++ b/src/seam-connect/client.ts
@@ -216,7 +216,10 @@ const getAuthHeaders = ({
     if (!clientSessionToken.startsWith("seam_cst")) {
       throw new Error("clientSessionToken must start with seam_cst")
     }
-    return { "client-session-token": clientSessionToken }
+    return {
+      authorization: `Bearer ${clientSessionToken}`,
+      "client-session-token": clientSessionToken,
+    }
   }
 
   if (apiKey) {
@@ -224,7 +227,7 @@ const getAuthHeaders = ({
       console.warn(
         "Using API Key as Client Session Token is deprecated. Please use the clientSessionToken option instead."
       )
-      return { "client-session-token": apiKey }
+      return { authorization: `Bearer ${apiKey}` }
     }
     if (!isValueUsedForBearerAuthentication(apiKey) && workspaceId)
       throw new Error(

--- a/src/seam-connect/client.ts
+++ b/src/seam-connect/client.ts
@@ -93,6 +93,7 @@ export class Seam extends Routes {
       ] = `Javascript SDK v${version}, Node.js mode, (https://github.com/seamapi/javascript)`
     }
     this.client = axios.create({
+      withCredentials: clientSessionToken ? true : false,
       ...axiosOptions,
       baseURL: endpoint,
       headers,

--- a/src/seam-connect/client.ts
+++ b/src/seam-connect/client.ts
@@ -224,10 +224,7 @@ const getAuthHeaders = ({
 
   if (apiKey) {
     if (apiKey.startsWith("seam_cst")) {
-      console.warn(
-        "Using API Key as Client Session Token is deprecated. Please use the clientSessionToken option instead."
-      )
-      return { authorization: `Bearer ${apiKey}` }
+      throw new Error("You can't use a Client Session Token as an apiKey.")
     }
     if (!isValueUsedForBearerAuthentication(apiKey) && workspaceId)
       throw new Error(


### PR DESCRIPTION
I think using the custom header may have been a mistake and is partially responsible for the CORS cache issues. Using the `authorization` header should be more compatible with various protocol layers and give more predictable behavior. We can send both here as a test. We cannot remove the other one yet since CORS behavior depends on the presence of that header.